### PR TITLE
Treat boolean arguments as positionals

### DIFF
--- a/.changeset/fresh-adults-deliver.md
+++ b/.changeset/fresh-adults-deliver.md
@@ -1,0 +1,5 @@
+---
+"ultraflag": minor
+---
+
+Treat boolean arguments as positionals

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,6 @@ export function parse<
   if (argv.length === 0) return {} as Args<TArgs>;
   const obj = { ...defaults, _: [] } as unknown as Args<TArgs>;
 
-  const args = [];
   for (let i = 0; i < argv.length; i++) {
     const curr = argv[i];
     const next = argv[i + 1];
@@ -122,9 +121,14 @@ export function parse<
         }
       } else if (!curr.includes("=") && next && next[0] !== "-") {
         key = curr.replace(/^-{1,2}/, '');
-        value = next;
         t = type(key, types as any);
-        i++;
+        // treat boolean as flag without parameter
+        if (t === 'boolean') {
+          value = 'true';
+        } else {
+          value = next;
+          i++;
+        }
       } else {
         const eq = curr.indexOf('=');
         if (eq === -1) {
@@ -135,7 +139,7 @@ export function parse<
         }
         t = type(key, types as any);
       }
-      
+
       if ((!t || t === "boolean") && key.length > 3 && key.startsWith('no-')) {
         set(obj, key.slice(3), false)
       } else {

--- a/test/flags.test.ts
+++ b/test/flags.test.ts
@@ -194,7 +194,7 @@ describe("aliases", () => {
       _: [],
       help: true
     };
-    const result = parse(input, { alias: { h: 'help' }});
+    const result = parse(input, { alias: { h: 'help' } });
     expect(result).toEqual(output);
   });
 
@@ -241,6 +241,19 @@ describe("special cases", () => {
       _: ['-'],
     };
     const result = parse(input);
+    expect(result).toEqual(output);
+  });
+
+  it("string after boolean should be treated as positional", () => {
+    const input = ["--get", "http://my-url.com"];
+    const opts = {
+      boolean: ['get']
+    }
+    const output = {
+      "_": ["http://my-url.com"],
+      "get": true,
+    };
+    const result = parse(input, opts);
     expect(result).toEqual(output);
   });
 });


### PR DESCRIPTION
Here changed behavior of booleans to not "swallow" positionals after them.

For example `curl --get http://my-url.com` where --get is boolean I need to get `{ get: true, _: ['http://my-url.com'] }`.

Node's parseArgs works the same way.

This is required for https://github.com/webstudio-is/webstudio/issues/4661